### PR TITLE
Add leaderboard-submission tooling + timestamps/save-all-steps support

### DIFF
--- a/rt/data.py
+++ b/rt/data.py
@@ -136,6 +136,7 @@ class RelationalDataset(Dataset):
         out["is_targets"] = out["is_targets"].view(-1, self.seq_len)
         out["is_task_nodes"] = out["is_task_nodes"].view(-1, self.seq_len)
         out["is_padding"] = out["is_padding"].view(-1, self.seq_len)
+        out["timestamps"] = out["timestamps"].view(-1, self.seq_len)
         out["table_name_idxs"] = out["table_name_idxs"].view(-1, self.seq_len)
         out["col_name_idxs"] = out["col_name_idxs"].view(-1, self.seq_len)
         out["class_value_idxs"] = out["class_value_idxs"].view(-1, self.seq_len)

--- a/rt/main.py
+++ b/rt/main.py
@@ -375,6 +375,11 @@ def main(
             ):
                 metrics = evaluate(net)
                 if save_ckpt_dir is not None:
+                    # RT_SAVE_ALL_STEPS=1 -> snapshot every eval step (steps=N.pt) so a caller can
+                    # post-hoc select by a metric other than the val-R2/AUC used here (e.g. val-NMAE
+                    # for regression). Off by default (preserves original behaviour).
+                    if os.environ.get("RT_SAVE_ALL_STEPS") == "1":
+                        checkpoint()
                     for (db_name, table_name), metric in metrics["val"].items():
                         # Eval metric is always higher is better (auc, r2)
                         best_metric = best_val_metrics.get(

--- a/rustler/src/fly.rs
+++ b/rustler/src/fly.rs
@@ -40,6 +40,7 @@ struct Vecs {
     is_targets: Vec<bool>,
     is_task_nodes: Vec<bool>,
     is_padding: Vec<bool>,
+    timestamps: Vec<i32>,
     true_batch_size: usize,
 }
 
@@ -59,6 +60,7 @@ struct Slices<'a> {
     is_targets: &'a mut [bool],
     is_task_nodes: &'a mut [bool],
     is_padding: &'a mut [bool],
+    timestamps: &'a mut [i32],
 }
 
 impl Vecs {
@@ -80,6 +82,7 @@ impl Vecs {
             is_targets: vec![false; l],
             is_task_nodes: vec![false; l],
             is_padding: vec![true; l],
+            timestamps: vec![i32::MIN; l],
             true_batch_size,
         }
     }
@@ -101,6 +104,7 @@ impl Vecs {
             self.is_targets.chunks_exact_mut(seq_len),
             self.is_task_nodes.chunks_exact_mut(seq_len),
             self.is_padding.chunks_exact_mut(seq_len),
+            self.timestamps.chunks_exact_mut(seq_len),
         )
         .map(
             |(
@@ -119,6 +123,7 @@ impl Vecs {
                 is_targets,
                 is_task_nodes,
                 is_padding,
+                timestamps,
             )| Slices {
                 node_idxs,
                 f2p_nbr_idxs,
@@ -135,6 +140,7 @@ impl Vecs {
                 is_targets,
                 is_task_nodes,
                 is_padding,
+                timestamps,
             },
         )
     }
@@ -198,6 +204,9 @@ impl Vecs {
                 .into_py_any(py)
                 .unwrap(),
             ("is_padding", PyArray1::from_vec(py, self.is_padding))
+                .into_py_any(py)
+                .unwrap(),
+            ("timestamps", PyArray1::from_vec(py, self.timestamps))
                 .into_py_any(py)
                 .unwrap(),
             ("true_batch_size", self.true_batch_size)
@@ -498,6 +507,10 @@ impl Sampler {
                 slices.is_task_nodes[seq_i] =
                     node.is_task_node || (node.col_name_idxs[cell_i] == target_column);
                 slices.is_padding[seq_i] = false;
+                slices.timestamps[seq_i] = match node.timestamp.as_ref() {
+                    Some(ts) => (*ts).into(),
+                    None => i32::MIN,
+                };
 
                 seq_i += 1;
                 if seq_i >= self.seq_len {

--- a/scripts/predict_stage1.py
+++ b/scripts/predict_stage1.py
@@ -1,0 +1,129 @@
+"""Stage 1 (model env): run a trained RT / PluRel checkpoint on a task's TEST split and
+emit raw predictions keyed by the ENTITY KEY (entity node idx + timestamp). NO relbench dep.
+
+Output: .npz with [entity_node_idx, timestamp, pred]
+  - binary_classification: pred = probability in [0,1]  (sigmoid applied)
+  - regression:            pred = numeric value
+  - entity_node_idx = f2p_nbr_idxs[is_targets][:, 0]  (the seed task-node's parent = the entity
+    node, e.g. the driver). Stage2 subtracts the entity table's node_idx_offset to get the
+    relbench entity id, then joins on (entity_id, timestamp).
+  - timestamp = the `timestamps` batch field at the target position (unix seconds).
+
+WHY NOT row_index = node_idx - offset: the Rust preprocessing's node order is the parquet's
+PHYSICAL row order, which does NOT always equal a fresh pd.read_parquet() order (verified:
+rel-f1/driver-top3 matched, but rel-f1/driver-dnf did NOT -> AUC 0.50 vs true 0.63). The
+(entity, timestamp) key is order-independent and matches the relbench test table exactly
+(verified driver-dnf: label-match 1.000 via this key).
+"""
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+
+# rt/model.py does `flex_attention = torch.compile(flex_attention)` at import. On large
+# tasks the block-mask shapes recompile repeatedly and the compile can take >10 min and
+# never reach a batch. With RT_EAGER=1 we no-op torch.compile so flex_attention runs eager
+# (slower per batch but starts immediately and never recompiles) — set for big test sets.
+if os.environ.get("RT_EAGER") == "1":
+    _real_compile = torch.compile
+    torch.compile = lambda fn=None, *a, **k: (fn if fn is not None else (lambda f: f))
+else:
+    torch._dynamo.config.cache_size_limit = 64
+    torch._dynamo.config.accumulated_cache_size_limit = 256
+
+from rt.data import RelationalDataset
+from rt.model import RelationalTransformer
+
+if os.environ.get("RT_EAGER") == "1":
+    torch.compile = _real_compile  # restore after rt.model captured the no-op
+
+REG_TABLES = {
+    "item-sales", "user-ltv", "item-ltv", "post-votes", "site-success",
+    "study-adverse", "user-attendance", "driver-position", "ad-ctr",
+}
+
+
+def _node_idx_offset(db, table, split):
+    pre = Path(os.environ["HOME"]) / "scratch" / "pre" / db / "table_info.json"
+    info = json.loads(pre.read_text())
+    key = f"{table}:Db" if f"{table}:Db" in info else f"{table}:{split.capitalize()}"
+    return info[key]["node_idx_offset"]
+
+
+@torch.inference_mode()
+def main(db, table, target, ckpt, out, *, split="test", batch_size=32, num_workers=8,
+         max_bfs_width=256, embedding_model="all-MiniLM-L12-v2", d_text=384, seq_len=1024,
+         num_blocks=12, d_model=256, num_heads=8, d_ff=1024, device="cuda"):
+    task_type = "reg" if table in REG_TABLES else "clf"
+
+    net = RelationalTransformer(num_blocks=num_blocks, d_model=d_model, d_text=d_text,
+                                num_heads=num_heads, d_ff=d_ff)
+    net.load_state_dict(torch.load(Path(ckpt).expanduser(), map_location="cpu"))
+    net = net.to(device).to(torch.bfloat16).eval()
+
+    # RT uses seq_len=; PluRel renamed it to ctx_len=. Support both.
+    _ds_common = dict(
+        tasks=[(db, table, target, split, [])], batch_size=batch_size,
+        rank=0, world_size=1, max_bfs_width=max_bfs_width, embedding_model=embedding_model,
+        d_text=d_text, seed=0)
+    try:
+        ds = RelationalDataset(seq_len=seq_len, **_ds_common)
+    except TypeError:
+        ds = RelationalDataset(ctx_len=seq_len, **_ds_common)
+    ds.sampler.shuffle_py(0)
+    loader = torch.utils.data.DataLoader(ds, batch_size=None, num_workers=num_workers,
+                                         pin_memory=True, in_order=True)
+
+    n_batches = len(loader)
+    t0 = time.time()
+    ents, tss, vals = [], [], []
+    for bi, batch in enumerate(loader):
+        tbs = batch.pop("true_batch_size")
+        for k in batch:
+            batch[k] = batch[k].to(device, non_blocking=True)
+        batch["masks"][tbs:, :] = False
+        batch["is_targets"][tbs:, :] = False
+        batch["is_padding"][tbs:, :] = True
+        _, yhat = net(batch)
+        if bi == 0 or (bi + 1) % 50 == 0 or bi + 1 == n_batches:
+            el = time.time() - t0
+            print(f"  [{db}/{table}] batch {bi+1}/{n_batches} ({el:.0f}s, {el/(bi+1):.2f}s/batch)",
+                  flush=True)
+        is_t = batch["is_targets"].bool()
+        if task_type == "clf":
+            v = torch.sigmoid(yhat["boolean"][is_t].float()).flatten()
+        else:
+            v = yhat["number"][is_t].float().flatten()
+        # entity = the seed task-node's first foreign->primary neighbour (the entity node).
+        ent = batch["f2p_nbr_idxs"][:, :, 0][is_t].flatten()
+        ts = batch["timestamps"][is_t].flatten()
+        assert v.numel() == tbs and ent.numel() == tbs and ts.numel() == tbs
+        ents.append(ent.cpu().numpy())
+        tss.append(ts.cpu().numpy())
+        vals.append(v.cpu().numpy())
+
+    entity_node_idx = np.concatenate(ents).astype(np.int64)
+    timestamp = np.concatenate(tss).astype(np.int64)
+    pred = np.concatenate(vals).astype(np.float64)
+    Path(out).parent.mkdir(parents=True, exist_ok=True)
+    np.savez(out, entity_node_idx=entity_node_idx, timestamp=timestamp, pred=pred,
+             task_type=np.array(task_type))
+    print(f"[stage1 OK] {db}/{table} ({task_type}): {len(pred)} preds -> {out}")
+    print(f"  pred min={pred.min():.4g} max={pred.max():.4g} mean={pred.mean():.4g}")
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    for a in ["db", "table", "target", "ckpt", "out"]:
+        p.add_argument(f"--{a}", required=True)
+    p.add_argument("--batch_size", type=int, default=32)
+    p.add_argument("--num_workers", type=int, default=8)
+    p.add_argument("--device", default="cuda")
+    a = p.parse_args()
+    main(a.db, a.table, a.target, a.ckpt, a.out,
+         batch_size=a.batch_size, num_workers=a.num_workers, device=a.device)

--- a/scripts/predict_stage2.py
+++ b/scripts/predict_stage2.py
@@ -1,0 +1,94 @@
+"""Stage 2 (relbench-hf env): join stage-1 predictions to the relbench-hf leaderboard
+test-table keys via (entity_id, timestamp) and write a leaderboard-format prediction CSV.
+
+stage1 emits, per test prediction:
+  entity_node_idx = the entity (e.g. driver) node's absolute index,
+  timestamp       = unix seconds,
+  pred.
+We recover entity_id = entity_node_idx - <entity_table>:Db node_idx_offset (from
+~/scratch/pre/<db>/table_info.json), then join (entity_id, timestamp) to the relbench-hf
+core test table's (entity_col, time_col) to place each prediction on the right row.
+
+This is robust to the preprocessing's parquet physical row order (the old node_idx-offset
+positional mapping was wrong for some tasks, e.g. rel-f1/driver-dnf).
+"""
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from relbench.base import TaskType
+from relbench.load import load_task
+from relbench.hf import CORE_REPO
+from relbench.leaderboard import write_prediction_table
+
+PRE = Path(os.environ.get("RT_PRE", Path(os.environ["HOME"]) / "scratch" / "pre"))
+# relbench-1.x task parquets (train split target stats -> regression denormalization).
+RELBENCH_CACHE = Path(os.environ.get("RELBENCH_CACHE",
+                                     Path(os.environ["HOME"]) / ".cache" / "relbench"))
+
+
+def _entity_offset(db, entity_table):
+    info = json.loads((PRE / db / "table_info.json").read_text())
+    key = f"{entity_table}:Db"
+    if key not in info:
+        raise KeyError(f"{key} not in {db}/table_info.json (keys: {list(info)[:8]}...)")
+    return info[key]["node_idx_offset"]
+
+
+def _train_target_stats(db, table, target_col):
+    """Train-split target mean/std (ddof=1) — the normalization the preprocessing applied."""
+    pq = RELBENCH_CACHE / db / "tasks" / table / "train.parquet"
+    s = pd.read_parquet(pq)[target_col].astype(float)
+    std = s.std(ddof=1)
+    return float(s.mean()), float(std if std and std == std else 1.0)
+
+
+def main(db, table, pred_npz, out_dir):
+    task = load_task(f"{CORE_REPO}/{db}", table)
+    ec, tc = task.entity_col, task.time_col
+    entity_table = task.entity_table
+    masked = task.get_table("test", mask_input_cols=True).df.reset_index(drop=True)
+    n = len(masked)
+
+    off = _entity_offset(db, entity_table)
+    z = np.load(pred_npz, allow_pickle=True)
+    entity_id = (z["entity_node_idx"].astype(np.int64) - off)
+    ts = z["timestamp"].astype(np.int64)
+    pvals = z["pred"].astype(np.float64)
+
+    # Regression predictions are in normalized (z-score) space — denormalize to original scale
+    # using the train-split target stats (the same normalization rustler/src/pre.rs applied).
+    if task.task_type == TaskType.REGRESSION:
+        mean, std = _train_target_stats(db, table, task.target_col)
+        pvals = pvals * std + mean
+
+    key_to_pred = {(int(e), int(t)): p for e, t, p in zip(entity_id, ts, pvals)}
+
+    core_ts = (pd.to_datetime(masked[tc]).astype("int64") // 10**9).to_numpy()
+    core_ent = masked[ec].astype(np.int64).to_numpy()
+    full = np.array([key_to_pred.get((int(e), int(t)), np.nan)
+                     for e, t in zip(core_ent, core_ts)], dtype=np.float64)
+
+    covered = ~np.isnan(full)
+    if not covered.all():
+        print(f"[stage2 WARN] {int((~covered).sum())}/{n} core test rows unmatched "
+              f"(entity_table={entity_table}, off={off})")
+
+    out_csv = Path(out_dir) / f"{db}__{table}.csv"
+    write_prediction_table(task, full, out_csv)
+    print(f"[stage2 OK] {db}/{table}: matched {int(covered.sum())}/{n} -> {out_csv}")
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--db", required=True)
+    p.add_argument("--table", required=True)
+    p.add_argument("--pred", required=True)
+    p.add_argument("--out_dir", required=True)
+    a = p.parse_args()
+    main(a.db, a.table, a.pred, a.out_dir)


### PR DESCRIPTION
Tooling to produce RelBench (relbench-hf) leaderboard prediction CSVs from a trained checkpoint, plus two small enablers:

- rustler: emit per-position `timestamps` (parity with plurel) so predictions join to relbench test rows by (entity_id, timestamp) rather than fragile node order.
- rt/data.py: reshape the new timestamps field.
- rt/main.py: `RT_SAVE_ALL_STEPS` env to snapshot every eval step (off by default) for post-hoc val-metric selection (e.g. val-NMAE for regression).
- scripts/predict_stage1.py + predict_stage2.py: stage1 (model env) -> npz of (entity_node_idx, timestamp, pred); stage2 (relbench-hf env) -> leaderboard CSV via entity-key join, regression denormalized via train-split target stats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDRcVWDC91B1iy1PrdmTBr
